### PR TITLE
Implement quest completion, skill tracking, and audit log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # TaskForge
 Taskforge - a gamified productivity app that turns your daily tasks, habits, and goals into a role-playing game where you earn rewards and level up by completing them.
+
+## Features
+
+- Create quests with XP, main stat, and optional skill tags.
+- Complete quests to gain XP and stat points; skills earn 1 point per 30 XP.
+- Radar chart visualizes Main Stats; Skills page tracks accumulated skill points.
+- Completed quests move to an Audit Log where rewards can be undone.

--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ Taskforge - a gamified productivity app that turns your daily tasks, habits, and
 - Create quests with difficulty presets and time multipliers to determine XP, plus main stat and optional skill tags.
 - Delete, edit, or complete quests to gain XP; main stats earn 1 point per 300 XP and skills 1 point per 30 XP.
 - Radar chart visualizes Main Stats; Skills page lets you add skills and tracks accumulated points without levels.
-- Create and manage colored tags, select them on quests, and mark quests repeatable or as "Anti Quests" that subtract XP.
-- Completed quests move to an Audit Log (pruned to 200 entries) where rewards can be undone, and a hard reset requires typing the player name to confirm.
+- Create and manage colored tags with edit/delete controls, select them on quests, and mark quests repeatable or as "Anti Quests" that subtract XP.
+- Completed quests move to an Audit Log (pruned to 200 entries) where rewards, including gold, can be undone; a hard reset requires typing the player name to confirm.
+- Player leveling uses 50 XP per level, resets every 100 levels with a prestige point, updates titles and portrait images, and grants random gold based on quest difficulty.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Taskforge - a gamified productivity app that turns your daily tasks, habits, and
 ## Features
 
 - Create quests with difficulty presets and time multipliers to determine XP, plus main stat and optional skill tags.
-- Delete or complete quests to gain XP; main stats earn 1 point per 300 XP and skills 1 point per 30 XP.
-- Radar chart visualizes Main Stats; Skills page tracks accumulated skill points without levels.
-- Completed quests move to an Audit Log where rewards can be undone, and a hard reset requires typing the player name to confirm.
+- Delete, edit, or complete quests to gain XP; main stats earn 1 point per 300 XP and skills 1 point per 30 XP.
+- Radar chart visualizes Main Stats; Skills page lets you add skills and tracks accumulated points without levels.
+- Create and manage colored tags, select them on quests, and mark quests repeatable or as "Anti Quests" that subtract XP.
+- Completed quests move to an Audit Log (pruned to 200 entries) where rewards can be undone, and a hard reset requires typing the player name to confirm.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Taskforge - a gamified productivity app that turns your daily tasks, habits, and
 
 ## Features
 
-- Create quests with XP, main stat, and optional skill tags.
-- Complete quests to gain XP; main stats earn 1 point per 300 XP and skills 1 point per 30 XP.
-- Radar chart visualizes Main Stats; Skills page tracks accumulated skill points.
-- Completed quests move to an Audit Log where rewards can be undone.
+- Create quests with difficulty presets and time multipliers to determine XP, plus main stat and optional skill tags.
+- Delete or complete quests to gain XP; main stats earn 1 point per 300 XP and skills 1 point per 30 XP.
+- Radar chart visualizes Main Stats; Skills page tracks accumulated skill points without levels.
+- Completed quests move to an Audit Log where rewards can be undone, and a hard reset requires typing the player name to confirm.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Taskforge - a gamified productivity app that turns your daily tasks, habits, and
 ## Features
 
 - Create quests with XP, main stat, and optional skill tags.
-- Complete quests to gain XP and stat points; skills earn 1 point per 30 XP.
+- Complete quests to gain XP; main stats earn 1 point per 300 XP and skills 1 point per 30 XP.
 - Radar chart visualizes Main Stats; Skills page tracks accumulated skill points.
 - Completed quests move to an Audit Log where rewards can be undone.

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>TaskForge — Gamified Productivity</title>
   <meta name="description" content="Turn your day into an RPG. Create quests, earn XP, and level up Main Stats + Skills." />
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Crect width='256' height='256' rx='56' fill='%230ea5e9'/%3E%3Ctext x='50%25' y='55%25' text-anchor='middle' font-size='48' fill='white' font-family='monospace'%3ETF%3C/text%3E%3C/svg%3E" />
   <style>* { scrollbar-width: thin; }</style>
 </head>
@@ -44,11 +45,12 @@
             </div>
             <div class="mt-3 text-xs opacity-90">Next level at <span id="next-xp">100</span> XP</div>
 
-            <div class="mt-4 space-y-2">
-              <button id="btn-open-quests" class="w-full text-left font-semibold hover:text-sky-300">Quests</button>
-              <button id="btn-open-stats" class="w-full text-left font-semibold hover:text-sky-300">Main Stats</button>
-              <button id="btn-open-skills" class="w-full text-left font-semibold hover:text-sky-300">Skills</button>
-            </div>
+              <div class="mt-4 space-y-2">
+                <button id="btn-open-quests" class="w-full text-left font-semibold hover:text-sky-300">Quests</button>
+                <button id="btn-open-stats" class="w-full text-left font-semibold hover:text-sky-300">Main Stats</button>
+                <button id="btn-open-skills" class="w-full text-left font-semibold hover:text-sky-300">Skills</button>
+                <button id="btn-open-log" class="w-full text-left font-semibold hover:text-sky-300">Audit Log</button>
+              </div>
           </div>
         </div>
       </div>
@@ -73,10 +75,11 @@
                 <label class="text-sm opacity-80">Main Stat</label>
                 <select id="q-stat" class="w-full px-3 py-2 rounded bg-slate-800"></select>
               </div>
-              <div>
-                <label class="text-sm opacity-80">Skill (optional)</label>
-                <select id="q-skill" class="w-full px-3 py-2 rounded bg-slate-800"></select>
-              </div>
+                <div>
+                  <label class="text-sm opacity-80">Skill (optional)</label>
+                  <input id="q-skill" list="skill-list" class="w-full px-3 py-2 rounded bg-slate-800" />
+                  <datalist id="skill-list"></datalist>
+                </div>
               <div>
                 <label class="text-sm opacity-80">Remind</label>
                 <input id="q-due" type="datetime-local" class="w-full px-3 py-2 rounded bg-slate-800" />
@@ -93,61 +96,253 @@
             <div id="quest-list" class="mt-4 grid gap-3"></div>
           </div>
 
-          <div id="view-stats" class="hidden"><h2 class="text-xl font-semibold mb-3">Main Stats</h2><div id="stats-list"></div></div>
-          <div id="view-skills" class="hidden"><h2 class="text-xl font-semibold mb-3">Skills</h2><div id="skills-list"></div></div>
+            <div id="view-stats" class="hidden"><h2 class="text-xl font-semibold mb-3">Main Stats</h2><div id="stats-list"></div></div>
+            <div id="view-skills" class="hidden"><h2 class="text-xl font-semibold mb-3">Skills</h2><div id="skills-list"></div></div>
+            <div id="view-log" class="hidden"><h2 class="text-xl font-semibold mb-3">Audit Log</h2><div id="log-list"></div></div>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
   </div>
 
   <template id="tpl-quest">
     <div class="rounded-xl bg-slate-800 p-3 ring-1 ring-white/10">
       <div class="flex items-start justify-between gap-3">
         <div class="flex-1">
-          <div class="flex items-center gap-2">
-            <input type="checkbox" class="q-done size-5 accent-emerald-500" />
-            <h3 class="q-title font-semibold"></h3>
-            <span class="ml-2 text-xs px-2 py-0.5 rounded bg-sky-700/50">+<span class="q-xp"></span> XP</span>
-            <span class="ml-1 text-xs px-2 py-0.5 rounded bg-fuchsia-700/40 q-tag-stat"></span>
-            <span class="ml-1 text-xs px-2 py-0.5 rounded bg-amber-700/40 q-tag-skill hidden"></span>
-          </div>
+            <div class="flex items-center gap-2">
+              <button class="q-complete text-xs px-2 py-1 rounded bg-emerald-700 hover:bg-emerald-600">Completed</button>
+              <h3 class="q-title font-semibold"></h3>
+              <span class="ml-2 text-xs px-2 py-0.5 rounded bg-sky-700/50">+<span class="q-xp"></span> XP</span>
+              <span class="ml-1 text-xs px-2 py-0.5 rounded bg-fuchsia-700/40 q-tag-stat"></span>
+              <span class="ml-1 text-xs px-2 py-0.5 rounded bg-amber-700/40 q-tag-skill hidden"></span>
+            </div>
           <p class="q-notes text-sm opacity-85 mt-1"></p>
         </div>
       </div>
     </div>
   </template>
 
+  <template id="tpl-log">
+    <div class="rounded-xl bg-slate-800 p-3 ring-1 ring-white/10">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex-1">
+          <h3 class="l-title font-semibold"></h3>
+          <div class="text-xs opacity-70 mt-1">+<span class="l-xp"></span> XP <span class="l-stat"></span> <span class="l-skill"></span></div>
+          <p class="l-notes text-sm opacity-85 mt-1"></p>
+        </div>
+        <button class="l-undo text-xs px-2 py-1 rounded bg-rose-700 hover:bg-rose-600">Undo</button>
+      </div>
+    </div>
+  </template>
+
 <script>
-const DEFAULT_SAVE = { player:{name:"Bowl",level:1,xp:0,mainstats:{Strength:10,Dexterity:10,Constitution:10,Intelligence:10,Wisdom:10,Charisma:10},skills:{}}, quests:[] };
-const el=id=>document.getElementById(id);
-const state=JSON.parse(localStorage.getItem('taskforge_save')||'null')||structuredClone(DEFAULT_SAVE);
-function save(){localStorage.setItem('taskforge_save',JSON.stringify(state));}
-function show(view){['view-quests','view-stats','view-skills'].forEach(id=>el(id).classList.toggle('hidden',id!==view));}
-function render(){
-  // Populate selects
-  el('q-stat').innerHTML='<option value="">None</option>'+Object.keys(state.player.mainstats).map(n=>`<option value="${n}">${n}</option>`).join('');
-  el('q-skill').innerHTML='<option value="">None</option>'+Object.keys(state.player.skills).map(n=>`<option value="${n}">${n}</option>`).join('');
-  // Quest list
-  const list=el('quest-list'); list.innerHTML='';
-  if(state.quests.length===0){list.innerHTML='<div class="text-sm opacity-70">No quests yet.</div>';return;}
-  state.quests.forEach(q=>{
-    const node=el('tpl-quest').content.cloneNode(true);
-    node.querySelector('.q-title').textContent=q.title;
-    node.querySelector('.q-xp').textContent=q.xp;
-    node.querySelector('.q-tag-stat').textContent=q.stat;
-    if(q.skill){const s=node.querySelector('.q-tag-skill');s.textContent=q.skill;s.classList.remove('hidden');}
-    list.appendChild(node);
+const DEFAULT_SAVE = {
+  player: {
+    name: "Bowl",
+    level: 1,
+    xp: 0,
+    mainstats: {
+      Strength: 10,
+      Dexterity: 10,
+      Constitution: 10,
+      Intelligence: 10,
+      Wisdom: 10,
+      Charisma: 10
+    },
+    skills: {}
+  },
+  quests: [],
+  log: []
+};
+const el = id => document.getElementById(id);
+const state =
+  JSON.parse(localStorage.getItem("taskforge_save") || "null") ||
+  structuredClone(DEFAULT_SAVE);
+let statsChart = null;
+function save() {
+  localStorage.setItem("taskforge_save", JSON.stringify(state));
+}
+function show(view) {
+  ["view-quests", "view-stats", "view-skills", "view-log"].forEach(id =>
+    el(id).classList.toggle("hidden", id !== view)
+  );
+}
+function nextLevelXP() {
+  return state.player.level * 100;
+}
+function addXP(amount) {
+  state.player.xp += amount;
+  while (state.player.xp >= nextLevelXP()) {
+    state.player.xp -= nextLevelXP();
+    state.player.level++;
+  }
+}
+function completeQuest(id) {
+  const idx = state.quests.findIndex(q => q.id === id);
+  if (idx === -1) return;
+  const q = state.quests[idx];
+  addXP(q.xp);
+  if (q.stat) {
+    state.player.mainstats[q.stat] =
+      (state.player.mainstats[q.stat] || 0) + q.xp;
+  }
+  let sp = 0;
+  if (q.skill) {
+    sp = Math.floor(q.xp / 30);
+    state.player.skills[q.skill] =
+      (state.player.skills[q.skill] || 0) + sp;
+  }
+  state.quests.splice(idx, 1);
+  state.log.push({ ...q, skillPoints: sp, completedAt: Date.now() });
+  save();
+  render();
+}
+function undoQuest(id) {
+  const idx = state.log.findIndex(l => l.id === id);
+  if (idx === -1) return;
+  const q = state.log[idx];
+  state.player.xp -= q.xp;
+  while (state.player.xp < 0 && state.player.level > 1) {
+    state.player.level--;
+    state.player.xp += nextLevelXP();
+  }
+  if (q.stat) {
+    state.player.mainstats[q.stat] -= q.xp;
+  }
+  if (q.skill) {
+    state.player.skills[q.skill] -= q.skillPoints;
+    if (state.player.skills[q.skill] <= 0) delete state.player.skills[q.skill];
+  }
+  state.log.splice(idx, 1);
+  state.quests.push({
+    id: q.id,
+    title: q.title,
+    xp: q.xp,
+    stat: q.stat,
+    skill: q.skill,
+    notes: q.notes
   });
+  save();
+  render();
+}
+function render() {
+  el("player-name").value = state.player.name;
+  el("level").textContent = state.player.level;
+  el("xp").textContent = state.player.xp;
+  el("next-xp").textContent = nextLevelXP();
+  el("q-stat").innerHTML =
+    '<option value="">None</option>' +
+    Object.keys(state.player.mainstats)
+      .map(n => `<option value="${n}">${n}</option>`)
+      .join("");
+  el("skill-list").innerHTML = Object.keys(state.player.skills)
+    .map(n => `<option value="${n}">`)
+    .join("");
+  const qlist = el("quest-list");
+  qlist.innerHTML = "";
+  if (state.quests.length === 0) {
+    qlist.innerHTML = '<div class="text-sm opacity-70">No quests yet.</div>';
+  } else {
+    state.quests.forEach(q => {
+      const node = el("tpl-quest").content.cloneNode(true);
+      node.querySelector(".q-title").textContent = q.title;
+      node.querySelector(".q-xp").textContent = q.xp;
+      node.querySelector(".q-tag-stat").textContent = q.stat;
+      if (q.skill) {
+        const s = node.querySelector(".q-tag-skill");
+        s.textContent = q.skill;
+        s.classList.remove("hidden");
+      }
+      node.querySelector(".q-complete").onclick = () => completeQuest(q.id);
+      node.querySelector(".q-notes").textContent = q.notes;
+      qlist.appendChild(node);
+    });
+  }
+  const statsList = el("stats-list");
+  statsList.innerHTML = '<canvas id="stats-chart"></canvas>';
+  const ctx = el("stats-chart");
+  if (statsChart) statsChart.destroy();
+  statsChart = new Chart(ctx, {
+    type: "radar",
+    data: {
+      labels: Object.keys(state.player.mainstats),
+      datasets: [
+        {
+          label: "Stats",
+          data: Object.values(state.player.mainstats),
+          backgroundColor: "rgba(14,165,233,0.2)",
+          borderColor: "#0ea5e9"
+        }
+      ]
+    },
+    options: { scales: { r: { beginAtZero: true } } }
+  });
+  const skillsList = el("skills-list");
+  skillsList.innerHTML = "";
+  const sk = state.player.skills;
+  if (Object.keys(sk).length === 0) {
+    skillsList.innerHTML = '<div class="text-sm opacity-70">No skills yet.</div>';
+  } else {
+    Object.entries(sk).forEach(([n, v]) => {
+      const div = document.createElement("div");
+      div.textContent = `${n}: ${v}`;
+      skillsList.appendChild(div);
+    });
+  }
+  const logList = el("log-list");
+  logList.innerHTML = "";
+  if (state.log.length === 0) {
+    logList.innerHTML = '<div class="text-sm opacity-70">No completed quests yet.</div>';
+  } else {
+    state.log
+      .slice()
+      .reverse()
+      .forEach(l => {
+        const node = el("tpl-log").content.cloneNode(true);
+        node.querySelector(".l-title").textContent = l.title;
+        node.querySelector(".l-xp").textContent = l.xp;
+        node.querySelector(".l-stat").textContent = l.stat || "";
+        node.querySelector(".l-skill").textContent = l.skill
+          ? `(${l.skill}+${l.skillPoints})`
+          : "";
+        node.querySelector(".l-notes").textContent = l.notes;
+        node.querySelector(".l-undo").onclick = () => undoQuest(l.id);
+        logList.appendChild(node);
+      });
+  }
 }
 // Events
-el('btn-open-quests').onclick=()=>show('view-quests');
-el('btn-open-stats').onclick=()=>show('view-stats');
-el('btn-open-skills').onclick=()=>show('view-skills');
-el('btn-show-form').onclick=()=>{el('quest-form').classList.toggle('hidden');};
-el('quest-form').onsubmit=e=>{e.preventDefault();
-  const q={id:crypto.randomUUID(),title:el('q-title').value||'Untitled',xp:+el('q-xp').value,stat:el('q-stat').value,skill:el('q-skill').value,notes:el('q-notes').value};
-  state.quests.push(q); save(); render(); el('quest-form').reset(); el('quest-form').classList.add('hidden');};
-el('btn-clear-done').onclick=()=>{state.quests=[];save();render();};
+el("player-name").onchange = e => {
+  state.player.name = e.target.value;
+  save();
+};
+el("btn-open-quests").onclick = () => show("view-quests");
+el("btn-open-stats").onclick = () => show("view-stats");
+el("btn-open-skills").onclick = () => show("view-skills");
+el("btn-open-log").onclick = () => show("view-log");
+el("btn-show-form").onclick = () => {
+  el("quest-form").classList.toggle("hidden");
+};
+el("quest-form").onsubmit = e => {
+  e.preventDefault();
+  const q = {
+    id: crypto.randomUUID(),
+    title: el("q-title").value || "Untitled",
+    xp: +el("q-xp").value,
+    stat: el("q-stat").value,
+    skill: el("q-skill").value.trim(),
+    notes: el("q-notes").value
+  };
+  state.quests.push(q);
+  save();
+  render();
+  el("quest-form").reset();
+  el("quest-form").classList.add("hidden");
+};
+el("btn-clear-done").onclick = () => {
+  state.quests = [];
+  save();
+  render();
+};
 render();
 </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -62,33 +62,51 @@
           <div id="view-quests">
             <h2 class="text-xl font-semibold mb-3">Quests</h2>
             <button id="btn-show-form" class="px-4 py-2 mb-3 rounded bg-sky-700 hover:bg-sky-600">Create New Quest</button>
-            <form id="quest-form" class="hidden grid grid-cols-1 md:grid-cols-6 gap-2 items-end">
+            <form id="quest-form" class="hidden grid grid-cols-1 md:grid-cols-7 gap-2 items-end">
               <div class="md:col-span-2">
                 <label class="text-sm opacity-80">Title</label>
                 <input id="q-title" class="w-full px-3 py-2 rounded bg-slate-800" placeholder="Gym: Push Day" />
               </div>
               <div>
-                <label class="text-sm opacity-80">XP</label>
-                <input id="q-xp" type="number" min="0" step="5" class="w-full px-3 py-2 rounded bg-slate-800" value="25" />
+                <label class="text-sm opacity-80">Difficulty</label>
+                <select id="q-diff" class="w-full px-3 py-2 rounded bg-slate-800">
+                  <option value="500">Trivial (500 XP)</option>
+                  <option value="750">Routine (750 XP)</option>
+                  <option value="1000" selected>Standard (1,000 XP)</option>
+                  <option value="1500">Challenging (1,500 XP)</option>
+                  <option value="2750">Formative (2,750 XP)</option>
+                </select>
+              </div>
+              <div>
+                <label class="text-sm opacity-80">Time Completion</label>
+                <select id="q-time" class="w-full px-3 py-2 rounded bg-slate-800">
+                  <option value="0">&lt;1 hr (0x)</option>
+                  <option value="1.1">1 hr+ (1.1x)</option>
+                  <option value="1.2">4 hrs+ (1.2x)</option>
+                  <option value="1.5">12 hrs+ (1.5x)</option>
+                  <option value="1.75">24 hrs+ (1.75x)</option>
+                  <option value="2.25">Week(s)+ (2.25x)</option>
+                  <option value="3.5">Month(s)+ (3.5x)</option>
+                </select>
               </div>
               <div>
                 <label class="text-sm opacity-80">Main Stat</label>
                 <select id="q-stat" class="w-full px-3 py-2 rounded bg-slate-800"></select>
               </div>
-                <div>
-                  <label class="text-sm opacity-80">Skill (optional)</label>
-                  <input id="q-skill" list="skill-list" class="w-full px-3 py-2 rounded bg-slate-800" />
-                  <datalist id="skill-list"></datalist>
-                </div>
+              <div>
+                <label class="text-sm opacity-80">Skill (optional)</label>
+                <input id="q-skill" list="skill-list" class="w-full px-3 py-2 rounded bg-slate-800" />
+                <datalist id="skill-list"></datalist>
+              </div>
               <div>
                 <label class="text-sm opacity-80">Remind</label>
                 <input id="q-due" type="datetime-local" class="w-full px-3 py-2 rounded bg-slate-800" />
               </div>
-              <div class="md:col-span-6">
+              <div class="md:col-span-7">
                 <label class="text-sm opacity-80">Notes</label>
                 <textarea id="q-notes" class="w-full px-3 py-2 rounded bg-slate-800" rows="2"></textarea>
               </div>
-              <div class="md:col-span-6 flex gap-2">
+              <div class="md:col-span-7 flex gap-2">
                 <button class="px-4 py-2 rounded bg-emerald-700 hover:bg-emerald-600">Add Quest</button>
                 <button type="button" id="btn-clear-done" class="px-4 py-2 rounded bg-slate-800 hover:bg-slate-700">Clear Completed</button>
               </div>
@@ -106,17 +124,16 @@
 
   <template id="tpl-quest">
     <div class="rounded-xl bg-slate-800 p-3 ring-1 ring-white/10">
-      <div class="flex items-start justify-between gap-3">
-        <div class="flex-1">
-            <div class="flex items-center gap-2">
-              <button class="q-complete text-xs px-2 py-1 rounded bg-emerald-700 hover:bg-emerald-600">Completed</button>
-              <h3 class="q-title font-semibold"></h3>
-              <span class="ml-2 text-xs px-2 py-0.5 rounded bg-sky-700/50">+<span class="q-xp"></span> XP</span>
-              <span class="ml-1 text-xs px-2 py-0.5 rounded bg-fuchsia-700/40 q-tag-stat"></span>
-              <span class="ml-1 text-xs px-2 py-0.5 rounded bg-amber-700/40 q-tag-skill hidden"></span>
-            </div>
-          <p class="q-notes text-sm opacity-85 mt-1"></p>
-        </div>
+      <h3 class="q-title font-semibold"></h3>
+      <div class="mt-1 text-xs flex items-center gap-1">
+        <span class="px-2 py-0.5 rounded bg-sky-700/50">+<span class="q-xp"></span> XP</span>
+        <span class="px-2 py-0.5 rounded bg-fuchsia-700/40 q-tag-stat"></span>
+        <span class="px-2 py-0.5 rounded bg-amber-700/40 q-tag-skill hidden"></span>
+      </div>
+      <p class="q-notes text-sm opacity-85 mt-2"></p>
+      <div class="mt-3 flex gap-2">
+        <button class="q-complete flex-1 px-3 py-2 rounded bg-emerald-700 hover:bg-emerald-600 text-sm">Completed</button>
+        <button class="q-delete px-3 py-2 rounded bg-rose-700 hover:bg-rose-600 text-sm">Delete</button>
       </div>
     </div>
   </template>
@@ -198,6 +215,13 @@ function completeQuest(id) {
   save();
   render();
 }
+function deleteQuest(id) {
+  const idx = state.quests.findIndex(q => q.id === id);
+  if (idx === -1) return;
+  state.quests.splice(idx, 1);
+  save();
+  render();
+}
 function undoQuest(id) {
   const idx = state.log.findIndex(l => l.id === id);
   if (idx === -1) return;
@@ -258,6 +282,7 @@ function render() {
         s.classList.remove("hidden");
       }
       node.querySelector(".q-complete").onclick = () => completeQuest(q.id);
+      node.querySelector(".q-delete").onclick = () => deleteQuest(q.id);
       node.querySelector(".q-notes").textContent = q.notes;
       qlist.appendChild(node);
     });
@@ -280,7 +305,15 @@ function render() {
       ]
     },
     options: {
-      scales: { r: { beginAtZero: true, ticks: { stepSize: 1, backdropColor: 'transparent' } } },
+      scales: {
+        r: {
+          beginAtZero: true,
+          ticks: { display: false },
+          grid: { color: 'rgba(255,255,255,0.1)' },
+          angleLines: { color: 'rgba(255,255,255,0.1)' },
+          pointLabels: { color: '#cbd5e1' }
+        }
+      },
       plugins: { legend: { display: false } }
     }
   });
@@ -339,7 +372,7 @@ el("quest-form").onsubmit = e => {
   const q = {
     id: crypto.randomUUID(),
     title: el("q-title").value || "Untitled",
-    xp: +el("q-xp").value,
+    xp: Math.round(+el("q-diff").value * +el("q-time").value),
     stat: el("q-stat").value,
     skill: el("q-skill").value.trim(),
     notes: el("q-notes").value
@@ -354,6 +387,13 @@ el("btn-clear-done").onclick = () => {
   state.quests = [];
   save();
   render();
+};
+el("btn-reset").onclick = () => {
+  const confirmName = prompt(`Type your player name (${state.player.name}) to confirm reset`);
+  if (confirmName === state.player.name) {
+    localStorage.removeItem("taskforge_save");
+    location.reload();
+  }
 };
 render();
 </script>

--- a/index.html
+++ b/index.html
@@ -45,12 +45,13 @@
             </div>
             <div class="mt-3 text-xs opacity-90">Next level at <span id="next-xp">100</span> XP</div>
 
-              <div class="mt-4 space-y-2">
-                <button id="btn-open-quests" class="w-full text-left font-semibold hover:text-sky-300">Quests</button>
-                <button id="btn-open-stats" class="w-full text-left font-semibold hover:text-sky-300">Main Stats</button>
-                <button id="btn-open-skills" class="w-full text-left font-semibold hover:text-sky-300">Skills</button>
-                <button id="btn-open-log" class="w-full text-left font-semibold hover:text-sky-300">Audit Log</button>
-              </div>
+          <div class="mt-4 grid grid-cols-2 gap-2">
+            <button id="btn-open-quests" class="w-full text-left font-semibold hover:text-sky-300">Quests</button>
+            <button id="btn-open-stats" class="w-full text-left font-semibold hover:text-sky-300">Main Stats</button>
+            <button id="btn-open-skills" class="w-full text-left font-semibold hover:text-sky-300">Skills</button>
+            <button id="btn-open-tags" class="w-full text-left font-semibold hover:text-sky-300">Tags</button>
+            <button id="btn-open-log" class="w-full text-left font-semibold hover:text-sky-300 col-span-2">Audit Log</button>
+          </div>
           </div>
         </div>
       </div>
@@ -62,8 +63,8 @@
           <div id="view-quests">
             <h2 class="text-xl font-semibold mb-3">Quests</h2>
             <button id="btn-show-form" class="px-4 py-2 mb-3 rounded bg-sky-700 hover:bg-sky-600">Create New Quest</button>
-            <form id="quest-form" class="hidden grid grid-cols-1 md:grid-cols-7 gap-2 items-end">
-              <div class="md:col-span-2">
+            <form id="quest-form" class="hidden grid grid-cols-1 sm:grid-cols-2 md:grid-cols-7 gap-2 items-end">
+              <div class="md:col-span-2 sm:col-span-2">
                 <label class="text-sm opacity-80">Title</label>
                 <input id="q-title" class="w-full px-3 py-2 rounded bg-slate-800" placeholder="Gym: Push Day" />
               </div>
@@ -80,6 +81,7 @@
               <div>
                 <label class="text-sm opacity-80">Time Completion</label>
                 <select id="q-time" class="w-full px-3 py-2 rounded bg-slate-800">
+                  <option value="1" selected>None (1x)</option>
                   <option value="0">&lt;1 hr (0x)</option>
                   <option value="1.1">1 hr+ (1.1x)</option>
                   <option value="1.2">4 hrs+ (1.2x)</option>
@@ -90,49 +92,70 @@
                 </select>
               </div>
               <div>
+                <label class="text-sm opacity-80">Skill</label>
+                <select id="q-skill" class="w-full px-3 py-2 rounded bg-slate-800"></select>
+              </div>
+              <div>
                 <label class="text-sm opacity-80">Main Stat</label>
                 <select id="q-stat" class="w-full px-3 py-2 rounded bg-slate-800"></select>
               </div>
               <div>
-                <label class="text-sm opacity-80">Skill (optional)</label>
-                <input id="q-skill" list="skill-list" class="w-full px-3 py-2 rounded bg-slate-800" />
-                <datalist id="skill-list"></datalist>
+                <label class="text-sm opacity-80">Tag</label>
+                <select id="q-tag" class="w-full px-3 py-2 rounded bg-slate-800"></select>
               </div>
               <div>
-                <label class="text-sm opacity-80">Remind</label>
+                <label class="text-sm opacity-80">Due</label>
                 <input id="q-due" type="datetime-local" class="w-full px-3 py-2 rounded bg-slate-800" />
               </div>
-              <div class="md:col-span-7">
+              <div class="sm:col-span-2 md:col-span-7 flex items-center gap-4">
+                <label class="flex items-center gap-2 text-sm"><input type="checkbox" id="q-repeat" class="rounded"> Repeatable</label>
+                <span id="q-anti" class="text-sm cursor-pointer text-rose-400">Anti Quest</span>
+              </div>
+              <div class="md:col-span-7 sm:col-span-2">
                 <label class="text-sm opacity-80">Notes</label>
                 <textarea id="q-notes" class="w-full px-3 py-2 rounded bg-slate-800" rows="2"></textarea>
               </div>
-              <div class="md:col-span-7 flex gap-2">
-                <button class="px-4 py-2 rounded bg-emerald-700 hover:bg-emerald-600">Add Quest</button>
+              <div class="md:col-span-7 sm:col-span-2 flex gap-2">
+                <button id="btn-submit-quest" class="px-4 py-2 rounded bg-emerald-700 hover:bg-emerald-600">Add Quest</button>
                 <button type="button" id="btn-clear-done" class="px-4 py-2 rounded bg-slate-800 hover:bg-slate-700">Clear Completed</button>
               </div>
             </form>
             <div id="quest-list" class="mt-4 grid gap-3"></div>
           </div>
 
-            <div id="view-stats" class="hidden"><h2 class="text-xl font-semibold mb-3">Main Stats</h2><div id="stats-list"></div></div>
-            <div id="view-skills" class="hidden"><h2 class="text-xl font-semibold mb-3">Skills</h2><div id="skills-list"></div></div>
-            <div id="view-log" class="hidden"><h2 class="text-xl font-semibold mb-3">Audit Log</h2><div id="log-list"></div></div>
+          <div id="view-stats" class="hidden"><h2 class="text-xl font-semibold mb-3">Main Stats</h2><div id="stats-list"></div></div>
+          <div id="view-skills" class="hidden">
+            <h2 class="text-xl font-semibold mb-3 flex items-center justify-between">Skills <button id="btn-add-skill" class="text-xs px-2 py-1 rounded bg-emerald-700 hover:bg-emerald-600">Add Skill</button></h2>
+            <div id="skills-list"></div>
           </div>
+          <div id="view-tags" class="hidden">
+            <h2 class="text-xl font-semibold mb-3">Tags</h2>
+            <div class="flex gap-2 mb-4">
+              <input id="tag-name" class="flex-1 px-3 py-2 rounded bg-slate-800" placeholder="Tag name" />
+              <input id="tag-color" type="color" value="#0ea5e9" class="w-14 h-10 p-0 border-0 rounded bg-slate-800" />
+              <button id="btn-add-tag" class="px-3 py-2 rounded bg-emerald-700 hover:bg-emerald-600">+</button>
+            </div>
+            <div id="tags-list"></div>
+          </div>
+          <div id="view-log" class="hidden"><h2 class="text-xl font-semibold mb-3">Audit Log</h2><div id="log-list"></div></div>
         </div>
-      </section>
+      </div>
+    </section>
   </div>
 
   <template id="tpl-quest">
-    <div class="rounded-xl bg-slate-800 p-3 ring-1 ring-white/10">
+    <div class="rounded-xl bg-slate-800 p-3 ring-1 ring-white/10 q-card">
       <h3 class="q-title font-semibold"></h3>
       <div class="mt-1 text-xs flex items-center gap-1">
-        <span class="px-2 py-0.5 rounded bg-sky-700/50">+<span class="q-xp"></span> XP</span>
+        <span class="px-2 py-0.5 rounded bg-sky-700/50"><span class="q-xp"></span> XP</span>
         <span class="px-2 py-0.5 rounded bg-fuchsia-700/40 q-tag-stat"></span>
         <span class="px-2 py-0.5 rounded bg-amber-700/40 q-tag-skill hidden"></span>
+        <span class="q-tag hidden px-2 py-0.5 rounded text-slate-900"></span>
       </div>
       <p class="q-notes text-sm opacity-85 mt-2"></p>
       <div class="mt-3 flex gap-2">
         <button class="q-complete flex-1 px-3 py-2 rounded bg-emerald-700 hover:bg-emerald-600 text-sm">Completed</button>
+        <button class="q-edit px-3 py-2 rounded bg-sky-700 hover:bg-sky-600 text-sm">Edit</button>
         <button class="q-delete px-3 py-2 rounded bg-rose-700 hover:bg-rose-600 text-sm">Delete</button>
       </div>
     </div>
@@ -143,7 +166,7 @@
       <div class="flex items-start justify-between gap-3">
         <div class="flex-1">
           <h3 class="l-title font-semibold"></h3>
-          <div class="text-xs opacity-70 mt-1">+<span class="l-xp"></span> XP <span class="l-stat"></span> <span class="l-skill"></span></div>
+          <div class="text-xs opacity-70 mt-1"><span class="l-xp"></span> XP <span class="l-stat"></span> <span class="l-skill"></span></div>
           <p class="l-notes text-sm opacity-85 mt-1"></p>
         </div>
         <button class="l-undo text-xs px-2 py-1 rounded bg-rose-700 hover:bg-rose-600">Undo</button>
@@ -168,18 +191,23 @@ const DEFAULT_SAVE = {
     skills: {}
   },
   quests: [],
-  log: []
+  log: [],
+  tags: []
 };
 const el = id => document.getElementById(id);
 const state =
   JSON.parse(localStorage.getItem("taskforge_save") || "null") ||
   structuredClone(DEFAULT_SAVE);
+if (!state.tags) state.tags = [];
+if (!state.player.skills) state.player.skills = {};
 let statsChart = null;
+let editingId = null;
+let antiQuest = false;
 function save() {
   localStorage.setItem("taskforge_save", JSON.stringify(state));
 }
 function show(view) {
-  ["view-quests", "view-stats", "view-skills", "view-log"].forEach(id =>
+  ["view-quests", "view-stats", "view-skills", "view-tags", "view-log"].forEach(id =>
     el(id).classList.toggle("hidden", id !== view)
   );
 }
@@ -192,6 +220,11 @@ function addXP(amount) {
     state.player.xp -= nextLevelXP();
     state.player.level++;
   }
+  while (state.player.xp < 0 && state.player.level > 1) {
+    state.player.level--;
+    state.player.xp += nextLevelXP();
+  }
+  if (state.player.xp < 0) state.player.xp = 0;
 }
 function completeQuest(id) {
   const idx = state.quests.findIndex(q => q.id === id);
@@ -200,18 +233,46 @@ function completeQuest(id) {
   addXP(q.xp);
   let st = 0;
   if (q.stat) {
-    st = Math.floor(q.xp / 300);
-    state.player.mainstats[q.stat] =
-      (state.player.mainstats[q.stat] || 0) + st;
+    st = Math.floor(Math.abs(q.xp) / 300);
+    const delta = q.xp < 0 ? -st : st;
+    state.player.mainstats[q.stat] = Math.max(
+      0,
+      (state.player.mainstats[q.stat] || 0) + delta
+    );
+    st = delta;
   }
   let sp = 0;
   if (q.skill) {
-    sp = Math.floor(q.xp / 30);
-    state.player.skills[q.skill] =
-      (state.player.skills[q.skill] || 0) + sp;
+    sp = Math.floor(Math.abs(q.xp) / 30);
+    const delta = q.xp < 0 ? -sp : sp;
+    state.player.skills[q.skill] = Math.max(
+      0,
+      (state.player.skills[q.skill] || 0) + delta
+    );
+    if (state.player.skills[q.skill] === 0) delete state.player.skills[q.skill];
+    sp = delta;
   }
-  state.quests.splice(idx, 1);
-  state.log.push({ ...q, statPoints: st, skillPoints: sp, completedAt: Date.now() });
+  const logEntry = {
+    id: crypto.randomUUID(),
+    questId: q.id,
+    title: q.title,
+    xp: q.xp,
+    diff: q.diff,
+    time: q.time,
+    stat: q.stat,
+    skill: q.skill,
+    tag: q.tag,
+    notes: q.notes,
+    repeat: q.repeat,
+    anti: q.anti,
+    due: q.due,
+    statPoints: st,
+    skillPoints: sp,
+    completedAt: Date.now()
+  };
+  state.log.push(logEntry);
+  if (state.log.length > 200) state.log.shift();
+  if (!q.repeat) state.quests.splice(idx, 1);
   save();
   render();
 }
@@ -222,36 +283,64 @@ function deleteQuest(id) {
   save();
   render();
 }
-function undoQuest(id) {
-  const idx = state.log.findIndex(l => l.id === id);
+function undoQuest(logId) {
+  const idx = state.log.findIndex(l => l.id === logId);
   if (idx === -1) return;
-  const q = state.log[idx];
-  state.player.xp -= q.xp;
+  const l = state.log[idx];
+  state.player.xp -= l.xp;
   while (state.player.xp < 0 && state.player.level > 1) {
     state.player.level--;
     state.player.xp += nextLevelXP();
   }
-  if (q.stat) {
-    state.player.mainstats[q.stat] = Math.max(
+  if (l.stat) {
+    state.player.mainstats[l.stat] = Math.max(
       0,
-      (state.player.mainstats[q.stat] || 0) - (q.statPoints || 0)
+      (state.player.mainstats[l.stat] || 0) - l.statPoints
     );
   }
-  if (q.skill) {
-    state.player.skills[q.skill] -= q.skillPoints;
-    if (state.player.skills[q.skill] <= 0) delete state.player.skills[q.skill];
+  if (l.skill) {
+    state.player.skills[l.skill] = Math.max(
+      0,
+      (state.player.skills[l.skill] || 0) - l.skillPoints
+    );
+    if (state.player.skills[l.skill] === 0) delete state.player.skills[l.skill];
   }
   state.log.splice(idx, 1);
-  state.quests.push({
-    id: q.id,
-    title: q.title,
-    xp: q.xp,
-    stat: q.stat,
-    skill: q.skill,
-    notes: q.notes
-  });
+  if (!l.repeat) {
+    state.quests.push({
+      id: l.questId,
+      title: l.title,
+      diff: l.diff,
+      time: l.time,
+      xp: l.xp,
+      stat: l.stat,
+      skill: l.skill,
+      tag: l.tag,
+      notes: l.notes,
+      repeat: l.repeat,
+      anti: l.anti,
+      due: l.due
+    });
+  }
   save();
   render();
+}
+function startEdit(id) {
+  const q = state.quests.find(q => q.id === id);
+  if (!q) return;
+  editingId = id;
+  antiQuest = q.anti || false;
+  el("quest-form").classList.remove("hidden");
+  el("q-title").value = q.title;
+  el("q-diff").value = q.diff || 1000;
+  el("q-time").value = q.time || 1;
+  el("q-skill").value = q.skill || "";
+  el("q-stat").value = q.stat || "";
+  el("q-tag").value = q.tag || "";
+  el("q-due").value = q.due || "";
+  el("q-repeat").checked = q.repeat || false;
+  el("q-notes").value = q.notes || "";
+  el("q-anti").classList.toggle("font-bold", antiQuest);
 }
 function render() {
   el("player-name").value = state.player.name;
@@ -263,9 +352,14 @@ function render() {
     Object.keys(state.player.mainstats)
       .map(n => `<option value="${n}">${n}</option>`)
       .join("");
-  el("skill-list").innerHTML = Object.keys(state.player.skills)
-    .map(n => `<option value="${n}">`)
-    .join("");
+  el("q-skill").innerHTML =
+    '<option value="">None</option>' +
+    Object.keys(state.player.skills)
+      .map(n => `<option value="${n}">${n}</option>`)
+      .join("");
+  el("q-tag").innerHTML =
+    '<option value="">None</option>' +
+    state.tags.map(t => `<option value="${t.id}">${t.name}</option>`).join("");
   const qlist = el("quest-list");
   qlist.innerHTML = "";
   if (state.quests.length === 0) {
@@ -274,15 +368,28 @@ function render() {
     state.quests.forEach(q => {
       const node = el("tpl-quest").content.cloneNode(true);
       node.querySelector(".q-title").textContent = q.title;
-      node.querySelector(".q-xp").textContent = q.xp;
+      node.querySelector(".q-xp").textContent = q.xp >= 0 ? `+${q.xp}` : q.xp;
       node.querySelector(".q-tag-stat").textContent = q.stat;
       if (q.skill) {
         const s = node.querySelector(".q-tag-skill");
         s.textContent = q.skill;
         s.classList.remove("hidden");
       }
+      if (q.tag) {
+        const t = state.tags.find(t => t.id === q.tag);
+        if (t) {
+          const tg = node.querySelector(".q-tag");
+          tg.textContent = t.name;
+          tg.style.backgroundColor = t.color;
+          tg.classList.remove("hidden");
+        }
+      }
+      if (q.anti) {
+        node.querySelector(".q-card").classList.add("bg-rose-900");
+      }
       node.querySelector(".q-complete").onclick = () => completeQuest(q.id);
       node.querySelector(".q-delete").onclick = () => deleteQuest(q.id);
+      node.querySelector(".q-edit").onclick = () => startEdit(q.id);
       node.querySelector(".q-notes").textContent = q.notes;
       qlist.appendChild(node);
     });
@@ -333,6 +440,18 @@ function render() {
       skillsList.appendChild(div);
     });
   }
+  const tagsList = el("tags-list");
+  tagsList.innerHTML = "";
+  if (state.tags.length === 0) {
+    tagsList.innerHTML = '<div class="text-sm opacity-70">No tags yet.</div>';
+  } else {
+    state.tags.forEach(t => {
+      const div = document.createElement("div");
+      div.className = "flex items-center gap-2 mb-1";
+      div.innerHTML = `<span class=\"w-4 h-4 rounded\" style=\"background:${t.color}\"></span>${t.name}`;
+      tagsList.appendChild(div);
+    });
+  }
   const logList = el("log-list");
   logList.innerHTML = "";
   if (state.log.length === 0) {
@@ -344,7 +463,7 @@ function render() {
       .forEach(l => {
         const node = el("tpl-log").content.cloneNode(true);
         node.querySelector(".l-title").textContent = l.title;
-        node.querySelector(".l-xp").textContent = l.xp;
+        node.querySelector(".l-xp").textContent = l.xp >= 0 ? `+${l.xp}` : l.xp;
         node.querySelector(".l-stat").textContent = l.stat || "";
         node.querySelector(".l-skill").textContent = l.skill
           ? `(${l.skill}+${l.skillPoints})`
@@ -354,6 +473,7 @@ function render() {
         logList.appendChild(node);
       });
   }
+  el("btn-submit-quest").textContent = editingId ? "Save Changes" : "Add Quest";
 }
 // Events
 el("player-name").onchange = e => {
@@ -363,21 +483,39 @@ el("player-name").onchange = e => {
 el("btn-open-quests").onclick = () => show("view-quests");
 el("btn-open-stats").onclick = () => show("view-stats");
 el("btn-open-skills").onclick = () => show("view-skills");
+el("btn-open-tags").onclick = () => show("view-tags");
 el("btn-open-log").onclick = () => show("view-log");
 el("btn-show-form").onclick = () => {
+  editingId = null;
+  antiQuest = false;
+  el("q-anti").classList.remove("font-bold");
+  el("quest-form").reset();
   el("quest-form").classList.toggle("hidden");
 };
 el("quest-form").onsubmit = e => {
   e.preventDefault();
+  const diff = +el("q-diff").value;
+  const time = +el("q-time").value;
+  const baseXP = Math.round(diff * time);
+  const xp = antiQuest ? Math.round(baseXP * -0.25) : baseXP;
   const q = {
-    id: crypto.randomUUID(),
+    id: editingId || crypto.randomUUID(),
     title: el("q-title").value || "Untitled",
-    xp: Math.round(+el("q-diff").value * +el("q-time").value),
+    diff,
+    time,
+    xp,
     stat: el("q-stat").value,
-    skill: el("q-skill").value.trim(),
+    skill: el("q-skill").value || "",
+    tag: el("q-tag").value || "",
+    due: el("q-due").value || "",
+    repeat: el("q-repeat").checked,
+    anti: antiQuest,
     notes: el("q-notes").value
   };
-  state.quests.push(q);
+  const existing = state.quests.findIndex(q => q.id === editingId);
+  if (existing !== -1) state.quests[existing] = q; else state.quests.push(q);
+  editingId = null;
+  antiQuest = false;
   save();
   render();
   el("quest-form").reset();
@@ -394,6 +532,28 @@ el("btn-reset").onclick = () => {
     localStorage.removeItem("taskforge_save");
     location.reload();
   }
+};
+el("btn-add-skill").onclick = () => {
+  const name = prompt("Skill name?");
+  if (name && !state.player.skills[name]) {
+    state.player.skills[name] = 0;
+    save();
+    render();
+  }
+};
+el("btn-add-tag").onclick = () => {
+  const name = el("tag-name").value.trim();
+  const color = el("tag-color").value;
+  if (name) {
+    state.tags.push({ id: crypto.randomUUID(), name, color });
+    el("tag-name").value = "";
+    save();
+    render();
+  }
+};
+el("q-anti").onclick = () => {
+  antiQuest = !antiQuest;
+  el("q-anti").classList.toggle("font-bold", antiQuest);
 };
 render();
 </script>

--- a/index.html
+++ b/index.html
@@ -30,29 +30,41 @@
           <h2 class="text-xl font-semibold mb-3 flex items-center justify-between">Player
             <button id="btn-notify" class="text-xs px-2 py-1 rounded bg-sky-700 hover:bg-sky-600">Enable Notifications</button>
           </h2>
-          <div class="space-y-2">
-            <label class="block text-sm opacity-80">Name</label>
-            <input id="player-name" type="text" class="w-full px-3 py-2 rounded bg-slate-800" placeholder="Bowl" />
-            <div class="grid grid-cols-2 gap-2 mt-2">
-              <div class="rounded bg-slate-800 p-3">
-                <div class="text-3xl font-bold" id="level">1</div>
-                <div class="text-xs opacity-70">Level</div>
+            <div class="space-y-2">
+              <label class="block text-sm opacity-80">Name</label>
+              <input id="player-name" type="text" class="w-full px-3 py-2 rounded bg-slate-800" placeholder="Bowl" />
+              <div class="flex flex-col items-center mt-2">
+                <img id="player-img" src="Commoner.png" alt="Player" class="w-24 h-24 rounded-full object-cover" />
+                <div id="player-title" class="mt-2 font-semibold">Commoner</div>
               </div>
-              <div class="rounded bg-slate-800 p-3">
-                <div class="text-3xl font-bold" id="xp">0</div>
-                <div class="text-xs opacity-70">XP</div>
+              <div class="grid grid-cols-2 gap-2 mt-2">
+                <div class="rounded bg-slate-800 p-3">
+                  <div class="text-3xl font-bold" id="level">1</div>
+                  <div class="text-xs opacity-70">Level</div>
+                </div>
+                <div class="rounded bg-slate-800 p-3">
+                  <div class="text-3xl font-bold" id="xp">0</div>
+                  <div class="text-xs opacity-70">XP</div>
+                </div>
+                <div class="rounded bg-slate-800 p-3">
+                  <div class="text-3xl font-bold" id="prestige">0</div>
+                  <div class="text-xs opacity-70">Prestige</div>
+                </div>
+                <div class="rounded bg-slate-800 p-3">
+                  <div class="text-3xl font-bold" id="gold">0</div>
+                  <div class="text-xs opacity-70">Gold</div>
+                </div>
               </div>
-            </div>
-            <div class="mt-3 text-xs opacity-90">Next level at <span id="next-xp">100</span> XP</div>
+              <div class="mt-3 text-xs opacity-90">Next level at <span id="next-xp">50</span> XP</div>
 
-          <div class="mt-4 grid grid-cols-2 gap-2">
-            <button id="btn-open-quests" class="w-full text-left font-semibold hover:text-sky-300">Quests</button>
-            <button id="btn-open-stats" class="w-full text-left font-semibold hover:text-sky-300">Main Stats</button>
-            <button id="btn-open-skills" class="w-full text-left font-semibold hover:text-sky-300">Skills</button>
-            <button id="btn-open-tags" class="w-full text-left font-semibold hover:text-sky-300">Tags</button>
-            <button id="btn-open-log" class="w-full text-left font-semibold hover:text-sky-300 col-span-2">Audit Log</button>
-          </div>
-          </div>
+            <div class="mt-4 grid grid-cols-2 gap-2">
+              <button id="btn-open-quests" class="w-full text-left font-semibold hover:text-sky-300">Quests</button>
+              <button id="btn-open-stats" class="w-full text-left font-semibold hover:text-sky-300">Main Stats</button>
+              <button id="btn-open-skills" class="w-full text-left font-semibold hover:text-sky-300">Skills</button>
+              <button id="btn-open-tags" class="w-full text-left font-semibold hover:text-sky-300">Tags</button>
+              <button id="btn-open-log" class="w-full text-left font-semibold hover:text-sky-300 col-span-2">Audit Log</button>
+            </div>
+            </div>
         </div>
       </div>
 
@@ -180,6 +192,8 @@ const DEFAULT_SAVE = {
     name: "Bowl",
     level: 1,
     xp: 0,
+    prestige: 0,
+    gold: 0,
     mainstats: {
       Strength: 0,
       Dexterity: 0,
@@ -200,9 +214,37 @@ const state =
   structuredClone(DEFAULT_SAVE);
 if (!state.tags) state.tags = [];
 if (!state.player.skills) state.player.skills = {};
+if (state.player.prestige === undefined) state.player.prestige = 0;
+if (state.player.gold === undefined) state.player.gold = 0;
 let statsChart = null;
 let editingId = null;
 let antiQuest = false;
+const TITLE_TIERS = [
+  { level: 400, title: "Mortal Savant" },
+  { level: 350, title: "FalconKnight" },
+  { level: 300, title: "SpellSword" },
+  { level: 250, title: "SwordMaster" },
+  { level: 200, title: "Paladin" },
+  { level: 150, title: "Hero" },
+  { level: 125, title: "Mercenary" },
+  { level: 100, title: "Soilder" },
+  { level: 50, title: "Fighter" },
+  { level: 25, title: "Adventurer" },
+  { level: 1, title: "Commoner" }
+];
+function getTitle(level) {
+  return TITLE_TIERS.find(t => level >= t.level)?.title || "Commoner";
+}
+function rand(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+function goldForDiff(diff) {
+  if (diff <= 500) return rand(1, 5);
+  if (diff <= 750) return rand(5, 30);
+  if (diff <= 1000) return rand(25, 60);
+  if (diff <= 1500) return rand(70, 100);
+  return rand(100, 300);
+}
 function save() {
   localStorage.setItem("taskforge_save", JSON.stringify(state));
 }
@@ -211,21 +253,28 @@ function show(view) {
     el(id).classList.toggle("hidden", id !== view)
   );
 }
-function nextLevelXP() {
-  return state.player.level * 100;
-}
-function addXP(amount) {
-  state.player.xp += amount;
-  while (state.player.xp >= nextLevelXP()) {
-    state.player.xp -= nextLevelXP();
-    state.player.level++;
+  function nextLevelXP() {
+    const lvl = ((state.player.level - 1) % 100) + 1;
+    return lvl * 50;
   }
-  while (state.player.xp < 0 && state.player.level > 1) {
-    state.player.level--;
-    state.player.xp += nextLevelXP();
+  function addXP(amount) {
+    state.player.xp += amount;
+    while (state.player.xp >= nextLevelXP()) {
+      state.player.xp -= nextLevelXP();
+      state.player.level++;
+      if (state.player.level % 100 === 1) {
+        state.player.prestige = (state.player.prestige || 0) + 1;
+        state.player.xp = 0;
+        break;
+      }
+    }
+    while (state.player.xp < 0 && state.player.level > 1) {
+      state.player.level--;
+      if (state.player.level % 100 === 0 && state.player.prestige) state.player.prestige--;
+      state.player.xp += nextLevelXP();
+    }
+    if (state.player.xp < 0) state.player.xp = 0;
   }
-  if (state.player.xp < 0) state.player.xp = 0;
-}
 function completeQuest(id) {
   const idx = state.quests.findIndex(q => q.id === id);
   if (idx === -1) return;
@@ -252,6 +301,9 @@ function completeQuest(id) {
     if (state.player.skills[q.skill] === 0) delete state.player.skills[q.skill];
     sp = delta;
   }
+  const gold = goldForDiff(q.diff);
+  state.player.gold += gold;
+  alert(`You earned ${gold} gold`);
   const logEntry = {
     id: crypto.randomUUID(),
     questId: q.id,
@@ -268,6 +320,7 @@ function completeQuest(id) {
     due: q.due,
     statPoints: st,
     skillPoints: sp,
+    gold,
     completedAt: Date.now()
   };
   state.log.push(logEntry);
@@ -283,15 +336,34 @@ function deleteQuest(id) {
   save();
   render();
 }
+function editTag(id) {
+  const t = state.tags.find(t => t.id === id);
+  if (!t) return;
+  const name = prompt("Tag name", t.name);
+  const color = prompt("Tag color", t.color);
+  if (name) {
+    t.name = name;
+    if (color) t.color = color;
+    save();
+    render();
+  }
+}
+function deleteTag(id) {
+  const idx = state.tags.findIndex(t => t.id === id);
+  if (idx === -1) return;
+  state.tags.splice(idx, 1);
+  state.quests.forEach(q => {
+    if (q.tag === id) q.tag = "";
+  });
+  save();
+  render();
+}
 function undoQuest(logId) {
   const idx = state.log.findIndex(l => l.id === logId);
   if (idx === -1) return;
   const l = state.log[idx];
-  state.player.xp -= l.xp;
-  while (state.player.xp < 0 && state.player.level > 1) {
-    state.player.level--;
-    state.player.xp += nextLevelXP();
-  }
+  addXP(-l.xp);
+  state.player.gold = Math.max(0, state.player.gold - (l.gold || 0));
   if (l.stat) {
     state.player.mainstats[l.stat] = Math.max(
       0,
@@ -342,16 +414,21 @@ function startEdit(id) {
   el("q-notes").value = q.notes || "";
   el("q-anti").classList.toggle("font-bold", antiQuest);
 }
-function render() {
-  el("player-name").value = state.player.name;
-  el("level").textContent = state.player.level;
-  el("xp").textContent = state.player.xp;
-  el("next-xp").textContent = nextLevelXP();
-  el("q-stat").innerHTML =
-    '<option value="">None</option>' +
-    Object.keys(state.player.mainstats)
-      .map(n => `<option value="${n}">${n}</option>`)
-      .join("");
+  function render() {
+    el("player-name").value = state.player.name;
+    el("level").textContent = state.player.level;
+    el("xp").textContent = state.player.xp;
+    el("prestige").textContent = state.player.prestige;
+    el("gold").textContent = state.player.gold;
+    const title = getTitle(state.player.level);
+    el("player-title").textContent = title;
+    el("player-img").src = `${title}.png`; // ensure png name matches title exactly
+    el("next-xp").textContent = nextLevelXP();
+    el("q-stat").innerHTML =
+      '<option value="">None</option>' +
+      Object.keys(state.player.mainstats)
+        .map(n => `<option value="${n}">${n}</option>`)
+        .join("");
   el("q-skill").innerHTML =
     '<option value="">None</option>' +
     Object.keys(state.player.skills)
@@ -447,8 +524,10 @@ function render() {
   } else {
     state.tags.forEach(t => {
       const div = document.createElement("div");
-      div.className = "flex items-center gap-2 mb-1";
-      div.innerHTML = `<span class=\"w-4 h-4 rounded\" style=\"background:${t.color}\"></span>${t.name}`;
+      div.className = "flex items-center gap-2 mb-1 text-sm";
+      div.innerHTML = `<span class=\"w-4 h-4 rounded\" style=\"background:${t.color}\"></span><span class=\"flex-1\">${t.name}</span><span class=\"cursor-pointer text-sky-400\" data-act=\"edit\">edit</span><span class=\"cursor-pointer text-rose-400\" data-act=\"del\">delete</span>`;
+      div.querySelector('[data-act="edit"]').onclick = () => editTag(t.id);
+      div.querySelector('[data-act="del"]').onclick = () => deleteTag(t.id);
       tagsList.appendChild(div);
     });
   }

--- a/index.html
+++ b/index.html
@@ -141,12 +141,12 @@ const DEFAULT_SAVE = {
     level: 1,
     xp: 0,
     mainstats: {
-      Strength: 10,
-      Dexterity: 10,
-      Constitution: 10,
-      Intelligence: 10,
-      Wisdom: 10,
-      Charisma: 10
+      Strength: 0,
+      Dexterity: 0,
+      Constitution: 0,
+      Intelligence: 0,
+      Wisdom: 0,
+      Charisma: 0
     },
     skills: {}
   },
@@ -181,9 +181,11 @@ function completeQuest(id) {
   if (idx === -1) return;
   const q = state.quests[idx];
   addXP(q.xp);
+  let st = 0;
   if (q.stat) {
+    st = Math.floor(q.xp / 300);
     state.player.mainstats[q.stat] =
-      (state.player.mainstats[q.stat] || 0) + q.xp;
+      (state.player.mainstats[q.stat] || 0) + st;
   }
   let sp = 0;
   if (q.skill) {
@@ -192,7 +194,7 @@ function completeQuest(id) {
       (state.player.skills[q.skill] || 0) + sp;
   }
   state.quests.splice(idx, 1);
-  state.log.push({ ...q, skillPoints: sp, completedAt: Date.now() });
+  state.log.push({ ...q, statPoints: st, skillPoints: sp, completedAt: Date.now() });
   save();
   render();
 }
@@ -206,7 +208,10 @@ function undoQuest(id) {
     state.player.xp += nextLevelXP();
   }
   if (q.stat) {
-    state.player.mainstats[q.stat] -= q.xp;
+    state.player.mainstats[q.stat] = Math.max(
+      0,
+      (state.player.mainstats[q.stat] || 0) - (q.statPoints || 0)
+    );
   }
   if (q.skill) {
     state.player.skills[q.skill] -= q.skillPoints;
@@ -258,7 +263,8 @@ function render() {
     });
   }
   const statsList = el("stats-list");
-  statsList.innerHTML = '<canvas id="stats-chart"></canvas>';
+  statsList.innerHTML =
+    '<canvas id="stats-chart"></canvas><table id="stats-table" class="mt-4 w-full text-sm"></table>';
   const ctx = el("stats-chart");
   if (statsChart) statsChart.destroy();
   statsChart = new Chart(ctx, {
@@ -267,15 +273,21 @@ function render() {
       labels: Object.keys(state.player.mainstats),
       datasets: [
         {
-          label: "Stats",
           data: Object.values(state.player.mainstats),
           backgroundColor: "rgba(14,165,233,0.2)",
           borderColor: "#0ea5e9"
         }
       ]
     },
-    options: { scales: { r: { beginAtZero: true } } }
+    options: {
+      scales: { r: { beginAtZero: true, ticks: { stepSize: 1, backdropColor: 'transparent' } } },
+      plugins: { legend: { display: false } }
+    }
   });
+  const statsTable = el("stats-table");
+  statsTable.innerHTML = Object.entries(state.player.mainstats)
+    .map(([n, v]) => `<tr><td class="py-1">${n}</td><td class="py-1 text-right">${v}</td></tr>`)
+    .join("");
   const skillsList = el("skills-list");
   skillsList.innerHTML = "";
   const sk = state.player.skills;

--- a/titlereq.txt
+++ b/titlereq.txt
@@ -1,0 +1,11 @@
+Commoner - Level 1
+Adventurer - Level 25
+Fighter - Level 50
+Soilder - Level 100
+Mercenary - Level 125
+Hero - Level 150
+Paladin - Level 200
+SwordMaster - Level 250
+SpellSword - Level 300
+FalconKnight - Level 350
+Mortal Savant - Level 400


### PR DESCRIPTION
## Summary
- Add quest completion with XP and stat rewards plus skill points at 1 per 30 XP
- Display main stats on a radar chart and list accumulated skills
- Track completed quests in an audit log with undo support

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ca8464cc8323a6c719f804f3e008