### PR TITLE
Add dungeon timer, surrender option, and item audio customization

### DIFF
--- a/ASSET_REMINDER.txt
+++ b/ASSET_REMINDER.txt
@@ -1,0 +1,1 @@
+Always update the custom image system whenever adding new items, monsters, or other assets.

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
               <button id="btn-open-shop" class="w-full text-left font-semibold hover:text-sky-300">Shop</button>
               <button id="btn-open-inventory" class="w-full text-left font-semibold hover:text-sky-300">Inventory</button>
               <button id="btn-open-log" class="w-full text-left font-semibold hover:text-sky-300 col-span-2">Audit Log</button>
+              <button id="btn-open-dungeon" class="w-full text-left font-semibold hover:text-sky-300 col-span-2">Dungeon</button>
             </div>
             </div>
         </div>
@@ -100,10 +101,9 @@
                 </select>
               </div>
               <div>
-                <label class="text-sm opacity-80">Time Completion</label>
-                <select id="q-time" class="w-full px-3 py-2 rounded bg-slate-800">
+              <label class="text-sm opacity-80">Time Completion</label>
+              <select id="q-time" class="w-full px-3 py-2 rounded bg-slate-800">
                   <option value="1" selected>None (1x)</option>
-                  <option value="0">&lt;1 hr (0x)</option>
                   <option value="1.1">1 hr+ (1.1x)</option>
                   <option value="1.2">4 hrs+ (1.2x)</option>
                   <option value="1.5">12 hrs+ (1.5x)</option>
@@ -197,6 +197,17 @@
             <div id="inventory-list" class="grid grid-cols-3 gap-2"></div>
           </div>
           <div id="view-log" class="hidden"><h2 class="text-xl font-semibold mb-3">Audit Log</h2><div id="log-list"></div></div>
+          <div id="view-dungeon" class="hidden">
+            <h2 class="text-xl font-semibold mb-3">Dungeon</h2>
+            <div id="dungeon-stats" class="text-sm mb-3">
+              Highest Dungeon Run: <span id="dungeon-highest">0</span> Monster(s) Defeated<br/>
+              Current Run: <span id="dungeon-current">0</span> Monster(s) Defeated
+            </div>
+            <div id="dungeon-monster" class="mb-4 text-center"></div>
+            <div id="dungeon-log" class="text-xs space-y-1 mb-4"></div>
+            <div id="dungeon-quests" class="mb-4"></div>
+            <div id="dungeon-actions" class="text-center"></div>
+          </div>
           <div id="view-settings" class="hidden">
             <h2 class="text-xl font-semibold mb-3">Settings</h2>
             <div class="mb-4">
@@ -234,6 +245,13 @@
               </select>
               <h4 class="font-semibold mb-2">Titles</h4>
               <div id="dev-titles" class="space-y-2"></div>
+              <h4 class="font-semibold mb-2 mt-4">Assets</h4>
+              <div id="dev-monsters" class="space-y-2 mb-2"></div>
+              <label class="block mb-1 text-sm">Default Shop Item Image</label>
+              <input id="dev-shop-img" type="file" accept="image/png" class="w-full text-sm mb-4"/>
+              <h4 class="font-semibold mb-2">Item Audio</h4>
+              <div id="dev-item-audio" class="space-y-2 mb-2"></div>
+              <button id="dev-add-item-audio" class="px-2 py-1 rounded bg-slate-800 hover:bg-slate-700 text-sm mb-4">Add Item Audio</button>
             </div>
             <div class="mb-4">
               <h3 class="font-semibold mb-2">Danger Zone</h3>
@@ -318,7 +336,8 @@ const DEFAULT_SAVE = {
   shop: [],
   inventory: [],
   streak: { count: 0, last: 0 },
-  settings: { levelSound: 0, audioCollapsed: false, volume: 1, theme: "default", titles: {} }
+  settings: { levelSound: 0, audioCollapsed: false, volume: 1, theme: "default", titles: {}, monsterImages: {}, defaultShopImg: "", itemAudio: {} },
+  dungeon: { current: null, chat: [], currentRun: 0, highestRun: 0, usedLogs: [] }
 };
 const el = id => document.getElementById(id);
 const state =
@@ -337,10 +356,14 @@ if (state.player.gold === undefined) state.player.gold = 0;
 if (!state.shop) state.shop = [];
 if (!state.inventory) state.inventory = [];
 if (!state.streak) state.streak = { count: 0, last: 0 };
-if (!state.settings) state.settings = { levelSound: 0, audioCollapsed: false, volume: 1, theme: "default", titles: {} };
+if (!state.settings) state.settings = { levelSound: 0, audioCollapsed: false, volume: 1, theme: "default", titles: {}, monsterImages: {}, defaultShopImg: "", itemAudio: {} };
 if (state.settings.volume === undefined) state.settings.volume = 1;
 if (!state.settings.theme) state.settings.theme = "default";
 if (!state.settings.titles) state.settings.titles = {};
+if (!state.settings.monsterImages) state.settings.monsterImages = {};
+if (state.settings.defaultShopImg === undefined) state.settings.defaultShopImg = "";
+if (!state.settings.itemAudio) state.settings.itemAudio = {};
+if (!state.dungeon) state.dungeon = { current: null, chat: [], currentRun: 0, highestRun: 0, usedLogs: [] };
 state.quests.forEach(q => {
   if (q.stat && !q.stats) {
     q.stats = q.stat ? [q.stat] : [];
@@ -375,9 +398,34 @@ const levelSounds = [
   new Audio("Sound Effects/lvlupfallout.mp3"),
   new Audio("Sound Effects/lvlupskyrim.mp3")
 ];
+const attackSound = new Audio("Sound Effects/Attack.mp3");
 let currentLvlSound = null;
 goldSound.volume = state.settings.volume;
 levelSounds.forEach(s => (s.volume = state.settings.volume));
+attackSound.volume = state.settings.volume;
+let dungeonTimer = null;
+const consumeSound = new Audio("Sound Effects/consume.mp3");
+const drinkSound = new Audio("Sound Effects/drink.mp3");
+consumeSound.volume = state.settings.volume;
+drinkSound.volume = state.settings.volume;
+
+function playItemSound(item) {
+  const cfg = state.settings.itemAudio[item.title];
+  let audio;
+  if (cfg) {
+    if (cfg.type === "custom" && cfg.src) {
+      audio = new Audio(cfg.src);
+      audio.volume = state.settings.volume;
+    } else if (cfg.type === "drink") {
+      audio = drinkSound;
+    } else {
+      audio = consumeSound;
+    }
+  } else {
+    audio = /potion/i.test(item.title) ? drinkSound : consumeSound;
+  }
+  audio.play();
+}
 
 function showModal(content) {
   const box = el("modal-box");
@@ -491,8 +539,244 @@ function itemModal(item, idx) {
       state.inventory.splice(idx, 1);
       save();
       render();
-      goldSound.play();
+       playItemSound(item);
       closeModal();
+    };
+  }
+}
+function spawnMonster() {
+  const r = Math.random();
+  let tier;
+  if (r < 0.6) tier = 1;
+  else if (r < 0.85) tier = 2;
+  else if (r < 0.95) tier = 3;
+  else tier = 4;
+  const list = MONSTERS.filter(m => m.tier === tier);
+  const template = list[rand(0, list.length - 1)];
+  const base = monsterBaseHP(tier);
+  const hp = Math.round(base * (0.7 + Math.random() * 0.6));
+  const img =
+    state.settings.monsterImages[template.name] ||
+    `Sprites/${template.name}.png`;
+  state.dungeon.current = {
+    name: template.name,
+    tier,
+    weak: template.weak,
+    resist: template.resist,
+    ability: template.ability,
+    rewardXp: template.rewardXp,
+    rewardGold: template.rewardGold,
+    baseHp: base,
+    limit: template.limit || 30,
+    hp,
+    maxHp: hp,
+    img,
+    spawn: Date.now()
+  };
+  state.dungeon.chat = [];
+  state.dungeon.usedLogs = [];
+  save();
+  renderDungeon();
+}
+function attackDungeon(logId) {
+  const log = state.log.find(l => l.id === logId);
+  const m = state.dungeon.current;
+  if (!log || !m) return;
+  let dmg = log.xp / 100;
+  let bonus = 0;
+  const weakHit =
+    log.skills.some(sk => m.weak.includes(sk.name)) ||
+    log.stats.some(st => m.weak.includes(st.name));
+  log.skills.forEach(sk => {
+    if (m.weak.includes(sk.name)) bonus += state.player.skills[sk.name] || 0;
+    if (m.resist.includes(sk.name)) dmg *= 0.85;
+    if (m.weak.includes(sk.name)) dmg *= 1.15;
+  });
+  log.stats.forEach(st => {
+    if (m.weak.includes(st.name)) bonus += state.player.mainstats[st.name] || 0;
+    if (m.resist.includes(st.name)) dmg *= 0.85;
+    if (m.weak.includes(st.name)) dmg *= 1.15;
+  });
+  dmg += bonus;
+  let crit = 0;
+  if (weakHit && Math.random() < 0.1) {
+    crit = dmg;
+    dmg *= 2;
+  }
+  if (m.ability === "heal5" && Math.random() < 0.05) {
+    m.hp = Math.min(m.maxHp, m.hp + Math.floor(dmg));
+    state.dungeon.chat.push(`${state.player.name} attacks! result: ${log.xp} XP base, damage -${Math.floor(dmg)} (crit ${Math.floor(crit)}) HP ${m.hp}/${m.maxHp}`);
+  } else {
+    m.hp = Math.max(0, m.hp - Math.floor(dmg));
+    state.dungeon.chat.push(`${state.player.name} attacks! result: ${log.xp} XP base, damage ${Math.floor(dmg)} (crit ${Math.floor(crit)}) HP ${m.hp}/${m.maxHp}`);
+  }
+  attackSound.play();
+  state.dungeon.usedLogs.push(logId);
+  if (m.hp <= 0) {
+    state.dungeon.chat.push(`${m.name} defeated!`);
+    const base = m.baseHp || monsterBaseHP(m.tier);
+    const xpGain = (m.rewardXp || 0) + (m.maxHp - base) * 2;
+    const goldGain = m.rewardGold || 0;
+    addXP(xpGain);
+    state.player.gold += goldGain;
+    state.dungeon.chat.push(`Rewards: ${xpGain} XP, ${goldGain} Gold`);
+    state.dungeon.currentRun++;
+    if (state.dungeon.currentRun > state.dungeon.highestRun)
+      state.dungeon.highestRun = state.dungeon.currentRun;
+    state.dungeon.current = null;
+    save();
+    render();
+    setTimeout(() => {
+      spawnMonster();
+    }, 2000);
+    return;
+  }
+  save();
+  renderDungeon();
+}
+function renderDungeon() {
+  if (!state.dungeon) return;
+  const d = state.dungeon;
+  el("dungeon-highest").textContent = d.highestRun || 0;
+  el("dungeon-current").textContent = d.currentRun || 0;
+  const mDiv = el("dungeon-monster");
+  const logDiv = el("dungeon-log");
+  const qDiv = el("dungeon-quests");
+  const actDiv = el("dungeon-actions");
+  if (dungeonTimer) clearInterval(dungeonTimer);
+  mDiv.innerHTML = "";
+  logDiv.innerHTML = `<h3 class="font-semibold mb-1 text-sm">Dungeon Chat</h3>` + d.chat.map(c => `<div>${c}</div>`).join("");
+  qDiv.innerHTML = "";
+  actDiv.innerHTML = "";
+  if (!d.current) {
+    const btn = document.createElement("button");
+    btn.id = "btn-enter-dungeon";
+    btn.className = "px-4 py-2 rounded bg-sky-700 hover:bg-sky-600";
+    btn.textContent = "Enter Dungeon";
+    btn.onclick = () => confirmModal("Enter the dungeon?", spawnMonster);
+    mDiv.appendChild(btn);
+    return;
+  }
+  const m = d.current;
+  mDiv.innerHTML = `<img src="${m.img}" class="w-32 h-32 object-contain mx-auto mb-2"/><div class="font-semibold">${m.name}</div><div class="text-xs mb-2">${m.weak.length ? "+" + m.weak.join("/") + " " : ""}${m.resist.length ? "&darr;" + m.resist.join("/") : ""}</div><div class="w-full bg-slate-800 h-3 rounded mb-1"><div class="bg-rose-700 h-3 rounded" style="width:${(m.hp / m.maxHp) * 100}%"></div></div><div class="text-sm mb-1">HP: ${m.hp}/${m.maxHp}</div><div id="dungeon-timer" class="text-xs mb-2"></div>`;
+  const tDiv = mDiv.querySelector("#dungeon-timer");
+  function upd() {
+    const diff = m.spawn + m.limit * 24 * 60 * 60 * 1000 - Date.now();
+    if (diff <= 0) {
+      d.chat.push("Failure!");
+      d.current = null;
+      d.currentRun = 0;
+      save();
+      renderDungeon();
+    } else {
+      const days = Math.floor(diff / 86400000);
+      const hrs = pad(Math.floor((diff % 86400000) / 3600000));
+      const mins = pad(Math.floor((diff % 3600000) / 60000));
+      const secs = pad(Math.floor((diff % 60000) / 1000));
+      tDiv.textContent = `days until death: ${days}d ${hrs}h ${mins}m ${secs}s`;
+    }
+  }
+  upd();
+  dungeonTimer = setInterval(upd, 1000);
+  qDiv.innerHTML = "<h3 class=\"font-semibold mb-2\">Completed Quests</h3>";
+  const quests = state.log
+    .slice()
+    .reverse()
+    .filter(l => !d.usedLogs.includes(l.id))
+    .slice(0, 5);
+  if (quests.length === 0) {
+    qDiv.innerHTML += '<div class="text-xs opacity-70">No recent quests.</div>';
+  } else {
+    quests.forEach(l => {
+      const row = document.createElement("div");
+      row.className = "flex justify-between items-center text-sm mb-1";
+      row.innerHTML = `<span>${l.title} (${l.xp} XP)</span><button class="px-2 py-0.5 rounded bg-emerald-700 hover:bg-emerald-600">Attack</button>`;
+      row.querySelector("button").onclick = () => attackDungeon(l.id);
+      qDiv.appendChild(row);
+    });
+  }
+  const sBtn = document.createElement("button");
+  sBtn.id = "btn-surrender";
+  sBtn.className = "px-4 py-2 rounded bg-rose-700 hover:bg-rose-600";
+  sBtn.textContent = "Surrender";
+  sBtn.onclick = () => {
+    d.chat.push("You surrendered.");
+    d.current = null;
+    d.currentRun = 0;
+    save();
+    renderDungeon();
+  };
+  actDiv.appendChild(sBtn);
+}
+function renderDevMonsters() {
+  const container = el("dev-monsters");
+  container.innerHTML = "";
+  MONSTERS.forEach(m => {
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = `<label class=\"block text-sm\">${m.name}</label><input type=\"file\" data-monster=\"${m.name}\" accept=\"image/png\" class=\"w-full text-sm\"/>`;
+    const input = wrapper.querySelector("input");
+    input.onchange = e => {
+      const file = e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        state.settings.monsterImages[m.name] = reader.result;
+        save();
+        renderDungeon();
+      };
+      reader.readAsDataURL(file);
+    };
+    container.appendChild(wrapper);
+  });
+}
+function renderDevItemAudio() {
+  const container = el("dev-item-audio");
+  if (!container) return;
+  container.innerHTML = "";
+  Object.keys(state.settings.itemAudio).forEach(name => {
+    const entry = state.settings.itemAudio[name];
+    const wrap = document.createElement("div");
+    const label = document.createElement("label");
+    label.className = "block text-sm";
+    label.textContent = name;
+    const select = document.createElement("select");
+    select.className = "w-full px-2 py-1 rounded bg-slate-800 text-sm mb-1";
+    select.innerHTML = '<option value="consume">Consume</option><option value="drink">Drink</option><option value="custom">Custom</option>';
+    select.value = entry.type || "consume";
+    const file = document.createElement("input");
+    file.type = "file";
+    file.accept = "audio/*";
+    file.className = "w-full text-sm";
+    select.onchange = () => {
+      entry.type = select.value;
+      if (select.value !== "custom") delete entry.src;
+      save();
+    };
+    file.onchange = e => {
+      const f = e.target.files[0];
+      if (!f) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        entry.type = "custom";
+        entry.src = reader.result;
+        save();
+      };
+      reader.readAsDataURL(f);
+    };
+    wrap.appendChild(label);
+    wrap.appendChild(select);
+    wrap.appendChild(file);
+    container.appendChild(wrap);
+  });
+  const addBtn = el("dev-add-item-audio");
+  if (addBtn) {
+    addBtn.onclick = () => {
+      textModal("Item name", "", name => {
+        if (!name) return;
+        state.settings.itemAudio[name] = { type: "consume" };
+        save();
+        renderDevItemAudio();
+      });
     };
   }
 }
@@ -524,6 +808,31 @@ const STREAK_TIERS = [
 function getStreakTier(days) {
   return STREAK_TIERS.find(t => days >= t.days) || null;
 }
+const MONSTERS = [
+  { name: "Clair Obscur", tier: 4, weak: ["Reading", "Strategy"], resist: ["Mindfulness"], ability: "heal5", rewardXp: 15000, rewardGold: 2000, limit: 15 },
+  { name: "Red Eyes Black Dragon", tier: 4, weak: ["Strength", "Fitness"], resist: ["Vitality"], rewardXp: 12000, rewardGold: 1000, limit: 15 },
+  { name: "Golem", tier: 3, weak: ["Dexterity"], resist: ["Constitution"], rewardXp: 7000, rewardGold: 250 },
+  { name: "Grand Mimic", tier: 3, weak: ["Reading"], resist: ["Strength", "Constitution"], rewardXp: 7500, rewardGold: 3000 },
+  { name: "Mythic Succubus", tier: 3, weak: ["Cooking", "Charisma"], resist: ["Mindfulness", "Vitality"], rewardXp: 7250, rewardGold: 300 },
+  { name: "Necromancer", tier: 3, weak: ["Productivity"], resist: ["Reading", "Charisma"], rewardXp: 7250, rewardGold: 300 },
+  { name: "Catacomb Giant Spider", tier: 3, weak: ["Strategy"], resist: ["Dexterity", "Vitality"], rewardXp: 7000, rewardGold: 275 },
+  { name: "Cyclops", tier: 2, weak: ["Strength"], resist: ["Strategy"], rewardXp: 3500, rewardGold: 150 },
+  { name: "Mimic", tier: 2, weak: ["Strategy", "Reading"], resist: ["Mindfulness"], rewardXp: 3750, rewardGold: 175 },
+  { name: "Undead Royal Knight", tier: 2, weak: ["Constitution", "Strategy"], resist: ["Dexterity"], rewardXp: 3600, rewardGold: 150 },
+  { name: "Seer", tier: 2, weak: ["Study"], resist: ["Mindfulness", "Charisma"], rewardXp: 3400, rewardGold: 125 },
+  { name: "Toxic Evil Spirit", tier: 2, weak: ["Mindfulness"], resist: ["Vitality", "Productivity"], rewardXp: 3200, rewardGold: 100 },
+  { name: "Zombie Horde", tier: 2, weak: ["Constitution"], resist: ["Dexterity", "Study"], rewardXp: 3300, rewardGold: 125 },
+  { name: "Giant Spider", tier: 2, weak: ["Strategy"], resist: ["Vitality", "Mindfulness"], rewardXp: 3600, rewardGold: 150 },
+  { name: "Evil Spirit", tier: 1, weak: ["Study"], resist: ["Mindfulness", "Productivity"], rewardXp: 1000, rewardGold: 75 },
+  { name: "Powerful Evil Spirit", tier: 1, weak: ["Study"], resist: ["Mindfulness"], rewardXp: 2000, rewardGold: 90 },
+  { name: "Goblin Gang", tier: 1, weak: ["Dexterity", "Cooking"], resist: ["Charisma"], rewardXp: 2100, rewardGold: 100 }
+];
+function monsterBaseHP(tier) {
+  if (tier === 1) return 250;
+  if (tier === 2) return 575;
+  if (tier === 3) return 1300;
+  return 3750;
+}
 function rand(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
@@ -546,7 +855,8 @@ function show(view) {
     "view-shop",
     "view-inventory",
     "view-log",
-    "view-settings"
+    "view-settings",
+    "view-dungeon"
   ].forEach(id => el(id).classList.toggle("hidden", id !== view));
 }
   function nextLevelXP() {
@@ -980,6 +1290,9 @@ function startEdit(id) {
     el("dev-theme").value = state.settings.theme || "default";
     applyTheme();
     renderDevTitles();
+    renderDevMonsters();
+    renderDevItemAudio();
+    renderDungeon();
     el("q-stats").innerHTML = "";
     addStatRow();
     el("q-stat-adjust").checked = false;
@@ -1179,7 +1492,7 @@ function startEdit(id) {
             state.inventory.splice(idx, 1);
             save();
             render();
-            goldSound.play();
+            playItemSound(item);
           });
         };
         div.appendChild(btn);
@@ -1235,6 +1548,7 @@ el("btn-open-shop").onclick = () => show("view-shop");
 el("btn-open-inventory").onclick = () => show("view-inventory");
 el("btn-open-log").onclick = () => show("view-log");
 el("btn-open-settings").onclick = () => show("view-settings");
+el("btn-open-dungeon").onclick = () => { show("view-dungeon"); renderDungeon(); };
 el("btn-show-form").onclick = () => {
   editingId = null;
   antiQuest = false;
@@ -1310,6 +1624,16 @@ el("dev-theme").onchange = e => {
   applyTheme();
   save();
 };
+el("dev-shop-img").onchange = e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    state.settings.defaultShopImg = reader.result;
+    save();
+  };
+  reader.readAsDataURL(file);
+};
 el("btn-show-shop-form").onclick = () => {
   editingShopId = null;
   el("shop-form").reset();
@@ -1324,7 +1648,7 @@ el("shop-form").onsubmit = e => {
   const file = el("shop-img").files[0];
   const id = editingShopId || crypto.randomUUID();
   const finish = imgData => {
-    const item = { id, title, desc, cost, img: imgData || "", rebuy };
+    const item = { id, title, desc, cost, img: imgData || state.settings.defaultShopImg || "", rebuy };
     const idx = state.shop.findIndex(s => s.id === editingShopId);
     if (idx !== -1) state.shop[idx] = item; else state.shop.push(item);
     editingShopId = null;
@@ -1338,7 +1662,7 @@ el("shop-form").onsubmit = e => {
     reader.onload = () => finish(reader.result);
     reader.readAsDataURL(file);
   } else {
-    const existing = editingShopId ? state.shop.find(s => s.id === editingShopId)?.img || "" : "";
+    const existing = editingShopId ? state.shop.find(s => s.id === editingShopId)?.img || state.settings.defaultShopImg || "" : state.settings.defaultShopImg || "";
     finish(existing);
   }
 };
@@ -1426,6 +1750,9 @@ el("audio-volume").oninput = e => {
   state.settings.volume = v;
   goldSound.volume = v;
   levelSounds.forEach(s => (s.volume = v));
+  attackSound.volume = v;
+  consumeSound.volume = v;
+  drinkSound.volume = v;
   save();
 };
 el("q-anti").onclick = () => {


### PR DESCRIPTION
## Summary
- move dungeon chat above quest list and add surrender action
- track monster timers with 30-day limit (15-day for endgame) and auto-respawn
- enable per-item audio customization with consume/drink defaults in developer settings

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4aee206cc8323a5e6f35e5adb3666